### PR TITLE
Decrease startup delay by skipping Java online Certificate Revocation Lists check

### DIFF
--- a/package-linux_arm64.sh
+++ b/package-linux_arm64.sh
@@ -4,7 +4,7 @@ NAME=CaDoodle
 VERSION=0.0.1
 MAIN=com.commonwealthrobotics.Main
 
-sudo apt install fuse 
+sudo apt install fuse
 
 if [[ -z "${VERSION_SEMVER}" ]]; then
   VERSION=4.0.4
@@ -24,7 +24,7 @@ if test -d $JAVA_HOME/$JVM/; then
 else
 	rm -rf $JAVA_HOME
 	mkdir -p $JAVA_HOME
-	wget https://cdn.azul.com/zulu/bin/$ZIP 
+	wget https://cdn.azul.com/zulu/bin/$ZIP
 	tar -xvzf $ZIP -C $JAVA_HOME
 	mv $JAVA_HOME/$JVM/* $JAVA_HOME/
 fi
@@ -38,13 +38,11 @@ JAR_NAME=CaDoodleUpdater.jar
 echo "Test jar complete"
 ls -al $JAVA_HOME
 
-
-
 ICON=$NAME.png
 cp SourceIcon.png $ICON
 rm -rf $SCRIPT_DIR/$NAME
 rm -rf $SCRIPT_DIR/$NAME.AppDir
-BUILDDIR=CaDoodleUpdater/build/libs/ 
+BUILDDIR=CaDoodleUpdater/build/libs/
 TARGETJAR=CaDoodleUpdater.jar
 
 $JAVA_HOME/bin/jpackage --input $BUILDDIR \
@@ -53,13 +51,13 @@ $JAVA_HOME/bin/jpackage --input $BUILDDIR \
   --main-class $MAIN \
   --type app-image \
   --app-version $VERSION \
-  --java-options '--enable-preview'
- 
+  --java-options '--enable-preview -Dcom.sun.net.ssl.checkRevocation=false -Djava.security.revocation=false -Djava.security.egd=file:/dev/./urandom'
+
 mkdir -p $SCRIPT_DIR/$NAME.AppDir/usr/
 cp -r $SCRIPT_DIR/$NAME/* $SCRIPT_DIR/$NAME.AppDir/usr/
 
-mkdir -p  $NAME.AppDir/usr/share/applications
-mkdir -p  $NAME.AppDir/usr/share/icons/hicolor/256x256/apps
+mkdir -p $NAME.AppDir/usr/share/applications
+mkdir -p $NAME.AppDir/usr/share/icons/hicolor/256x256/apps
 
 cat << EOF > $NAME.AppDir/$NAME.desktop
 [Desktop Entry]
@@ -70,7 +68,6 @@ Type=Application
 Categories=Utility
 EOF
 
- 
 chmod 644 $NAME.AppDir/$NAME.desktop
 
 ln -s usr/bin/$NAME  $SCRIPT_DIR/$NAME.AppDir/AppRun
@@ -106,8 +103,8 @@ $JAVA_HOME/bin/jpackage --input $BUILDDIR \
   --icon $ICON \
   --copyright "Creative Commons" \
   --vendor CommonWealthRobotics \
- --linux-menu-group "Education;Graphics;Development;" \
-  --java-options '--enable-preview'
+  --linux-menu-group "Education;Graphics;Development;" \
+  --java-options '--enable-preview -Dcom.sun.net.ssl.checkRevocation=false -Djava.security.revocation=false -Djava.security.egd=file:/dev/./urandom'
 echo "Deb built!"
 ls -al
 rm -rf release
@@ -116,5 +113,3 @@ cp *.deb release/$NAME-Linux-$ARCH.deb
 cp $NAME-aarch64.AppImage release/$NAME-Linux-$ARCH.AppImage
 #sudo apt remove bowlerlauncher
 #sudo dpkg -i *.deb
-
-

--- a/package-linux_x64.sh
+++ b/package-linux_x64.sh
@@ -4,7 +4,7 @@ NAME=CaDoodle
 VERSION=0.0.1
 MAIN=com.commonwealthrobotics.Main
 
-sudo apt install fuse 
+sudo apt install fuse
 
 if [[ -z "${VERSION_SEMVER}" ]]; then
   VERSION=4.0.4
@@ -24,7 +24,7 @@ if test -d $JAVA_HOME/$JVM/; then
 else
 	rm -rf $JAVA_HOME
 	mkdir -p $JAVA_HOME
-	wget https://cdn.azul.com/zulu/bin/$ZIP 
+	wget https://cdn.azul.com/zulu/bin/$ZIP
 	tar -xvzf $ZIP -C $JAVA_HOME
 	mv $JAVA_HOME/$JVM/* $JAVA_HOME/
 fi
@@ -38,13 +38,11 @@ JAR_NAME=CaDoodleUpdater.jar
 echo "Test jar complete"
 ls -al $JAVA_HOME
 
-
-
 ICON=$NAME.png
 cp SourceIcon.png $ICON
 rm -rf $SCRIPT_DIR/$NAME
 rm -rf $SCRIPT_DIR/$NAME.AppDir
-BUILDDIR=CaDoodleUpdater/build/libs/ 
+BUILDDIR=CaDoodleUpdater/build/libs/
 TARGETJAR=CaDoodleUpdater.jar
 
 $JAVA_HOME/bin/jpackage --input $BUILDDIR \
@@ -53,8 +51,8 @@ $JAVA_HOME/bin/jpackage --input $BUILDDIR \
   --main-class $MAIN \
   --type app-image \
   --app-version $VERSION \
-  --java-options '--enable-preview'
- 
+  --java-options '--enable-preview -Dcom.sun.net.ssl.checkRevocation=false -Djava.security.revocation=false -Djava.security.egd=file:/dev/./urandom'
+
 mkdir -p $SCRIPT_DIR/$NAME.AppDir/usr/
 cp -r $SCRIPT_DIR/$NAME/* $SCRIPT_DIR/$NAME.AppDir/usr/
 
@@ -70,7 +68,6 @@ Type=Application
 Categories=Utility
 EOF
 
- 
 chmod 644 $NAME.AppDir/$NAME.desktop
 
 ln -s usr/bin/$NAME  $SCRIPT_DIR/$NAME.AppDir/AppRun
@@ -106,8 +103,9 @@ $JAVA_HOME/bin/jpackage --input $BUILDDIR \
   --icon $ICON \
   --copyright "Creative Commons" \
   --vendor CommonWealthRobotics \
- --linux-menu-group "Education;Graphics;Development;" \
-  --java-options '--enable-preview'
+  --linux-menu-group "Education;Graphics;Development;" \
+  --java-options '--enable-preview -Dcom.sun.net.ssl.checkRevocation=false -Djava.security.revocation=false -Djava.security.egd=file:/dev/./urandom'
+
 echo "Deb built!"
 ls -al
 rm -rf release

--- a/package-macos.sh
+++ b/package-macos.sh
@@ -14,10 +14,10 @@ ARCH=x86_64
 JVM=zulu17.50.19-ca-fx-jdk17.0.11-macosx_x64
 if [[ $(uname -m) == 'arm64' ]]; then
   ARCH=arm64
-  echo "M1 Mac detected https://cdn.azul.com/zulu/bin/zulu17.50.19-ca-fx-jdk17.0.11-macosx_aarch64.tar.gz" 
+  echo "M1 Mac detected https://cdn.azul.com/zulu/bin/zulu17.50.19-ca-fx-jdk17.0.11-macosx_aarch64.tar.gz"
   JVM=zulu17.50.19-ca-fx-jdk17.0.11-macosx_aarch64
 else
-  echo "x86 Mac detected https://cdn.azul.com/zulu/bin/zulu17.50.19-ca-fx-jdk17.0.11-macosx_x64.tar.gz" 
+  echo "x86 Mac detected https://cdn.azul.com/zulu/bin/zulu17.50.19-ca-fx-jdk17.0.11-macosx_x64.tar.gz"
 
 fi
 set -e
@@ -45,7 +45,7 @@ ICON=$NAME.png
 cp SourceIcon.png $ICON
 rm -rf $SCRIPT_DIR/$NAME
 rm -rf $SCRIPT_DIR/$NAME.AppDir
-BUILDDIR=CaDoodleUpdater/build/libs/ 
+BUILDDIR=CaDoodleUpdater/build/libs/
 TARGETJAR=CaDoodleUpdater.jar
 rm -rf *.dmg
 echo "Building DMG..."
@@ -73,7 +73,7 @@ $JAVA_HOME/bin/jpackage --input $BUILDDIR \
   --vendor "Common Wealth Robotics" \
   --icon $NAME.icns \
   --app-version "$VERSION" \
-  --java-options '--enable-preview'
+  --java-options '--enable-preview -Dcom.sun.net.ssl.checkRevocation=false -Djava.security.revocation=false'
 ls -al
 rm -rf release
 mkdir release

--- a/package-windows_x86_64.sh
+++ b/package-windows_x86_64.sh
@@ -44,7 +44,7 @@ magick SourceIcon.png -resize 48x48 your_image_48.png
 magick SourceIcon.png -resize 32x32 your_image_32.png
 magick SourceIcon.png -resize 16x16 your_image_16.png
 
-magick convert your_image_16.png your_image_32.png your_image_48.png your_image_64.png your_image_128.png your_image_256.png $NAME.ico 
+magick your_image_16.png your_image_32.png your_image_48.png your_image_64.png your_image_128.png your_image_256.png $NAME.ico 
     
 PACKAGE="$JAVA_HOME/bin/jpackage.exe"
 mkdir -p "$INPUT_DIR"

--- a/package-windows_x86_64.sh
+++ b/package-windows_x86_64.sh
@@ -27,7 +27,7 @@ else
 	7z x $ZIP -o"$JAVA_HOME"
 	mv "$JAVA_HOME/$JVM/"* "$JAVA_HOME/"
 fi
-echo "Compile wiht gradle"
+echo "Compile with gradle"
 ./gradlew shadowJar
 echo "Test jar in: $SCRIPT_DIR"
 DIR="$SCRIPT_DIR/CaDoodleUpdater/build/libs/"
@@ -37,12 +37,12 @@ JAR_NAME=CaDoodleUpdater.jar
 echo "Test jar complete"
 
 ICON=$NAME.ico
-magick convert SourceIcon.png -resize 256x256 your_image_256.png
-magick convert SourceIcon.png -resize 128x128 your_image_128.png
-magick convert SourceIcon.png -resize 64x64 your_image_64.png
-magick convert SourceIcon.png -resize 48x48 your_image_48.png
-magick convert SourceIcon.png -resize 32x32 your_image_32.png
-magick convert SourceIcon.png -resize 16x16 your_image_16.png
+magick SourceIcon.png -resize 256x256 your_image_256.png
+magick SourceIcon.png -resize 128x128 your_image_128.png
+magick SourceIcon.png -resize 64x64 your_image_64.png
+magick SourceIcon.png -resize 48x48 your_image_48.png
+magick SourceIcon.png -resize 32x32 your_image_32.png
+magick SourceIcon.png -resize 16x16 your_image_16.png
 
 magick convert your_image_16.png your_image_32.png your_image_48.png your_image_64.png your_image_128.png your_image_256.png $NAME.ico 
     
@@ -63,7 +63,7 @@ rm -rf $NAME
   --temp "temp1"  \
   --app-version "$VERSION" \
   --icon "$ICON" \
-  --java-options '--enable-preview'
+  --java-options '--enable-preview -Dcom.sun.net.ssl.checkRevocation=false -Djava.security.revocation=false'
   
 echo "Zipping standalone version"
 rm -rf *.zip
@@ -82,7 +82,7 @@ echo "Building Local installer"
   --win-menu \
   --win-dir-chooser \
   --win-per-user-install \
-  --java-options '--enable-preview'
+  --java-options '--enable-preview -Dcom.sun.net.ssl.checkRevocation=false -Djava.security.revocation=false'
 
 echo "Building system wide installer" 
   
@@ -97,7 +97,7 @@ echo "Building system wide installer"
   --win-shortcut \
   --win-menu \
   --win-dir-chooser \
-  --java-options '--enable-preview'
+  --java-options '--enable-preview -Dcom.sun.net.ssl.checkRevocation=false -Djava.security.revocation=false'
 
 ls -al
 rm -rf release


### PR DESCRIPTION
Decrease startup delay by skipping online Certificate Revocation Lists check.
This PR will decrease the offline startup time by 5-10 seconds

Reference: [#100](https://github.com/CommonWealthRobotics/CaDoodle-Application/issues/100)