### PR TITLE
Add Visual Studio Code support

### DIFF
--- a/CaDoodleUpdater/build.gradle
+++ b/CaDoodleUpdater/build.gradle
@@ -56,3 +56,27 @@ tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.Shadow
 application {
 	mainClass = 'com.commonwealthrobotics.Main'
 }
+
+// Create dependencies structure
+startScripts.dependsOn shadowJar
+startShadowScripts.dependsOn jar
+startShadowScripts.dependsOn shadowJar
+
+// Point the run/start scripts to the fat jar
+application {
+	mainClass = 'com.commonwealthrobotics.Main'
+	applicationDefaultJvmArgs = []
+	applicationDistribution.from(shadowJar) {
+		into 'lib'
+	}
+}
+
+// Use only the fat Jar
+distributions {
+	main {
+		contents {
+			exclude { f -> f.name.equals('CaDoodleUpdater.jar') && !f.name.contains('shadow') }
+			from shadowJar
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -43,3 +43,32 @@ CaDoodle-Windows-System-x86_64.exe /S
 CaDoodle-Windows-System-x86_64.exe /S /D=D:\CustomLocation\CaDoodle\
 
 ```
+
+# Visual Studio Code building the Java JAR file
+
+To build the updater Java JAR file in Visual Studio Code install the following extensions:
+1. Gradle for Java
+2. Language Support for Java(TM) by Red Hat
+
+Open the CaDoodleUpdater directory.
+
+When VS Code asks to use Gradle or Maven, select Gradle.
+
+To build the JAR file the Azul 17 Java-JavaFX JVM is required, it can be found here:
+https://www.azul.com/downloads/?version=java-17-lts&package=jdk-fx#zulu
+
+Supported platforms are Windows-x64, Linux-x64, Linux-ARM, Mac-x64 and Mac-ARM.
+Extract the JVM to a path without spaces in it.
+
+In the VS Code "settings.json" point to the files in the JVM:
+```
+"java.jdt.ls.java.home": "<YOUR_PATH>",
+"java.configuration.runtimes": "<YOUR_PATH>"
+```
+
+Both paths can point to the same directory (the JRE is included in the JVM).
+The java executable (java or java.exe) should be located in:
+```"<YOUR_PATH>\\bin\\"```
+
+Select the Gradle extension (elephant icon on the left), then select "CaDoodleUpdater/Tasks/build/build" to build the Jar file.
+The CaDoodleUpdater.jar file will be located in "CaDoodleUpdater\build\libs"


### PR DESCRIPTION
Add Visual Studio Code support
Install plugins:
1. Gradle for Java
2. Java Language Support

Make sure you point to the JDK and JRE:
    "java.jdt.ls.java.home": "C:\\<YOUR PATH>\\javaSKD",
    "java.configuration.runtimes": [
    "C:\\<YOUR PATH>\\javaJRE"]